### PR TITLE
Add benchmark for query execution

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject graphql-clj-bench "0.1.0-SNAPSHOT"
   :description "Benchmarks for 'tendant/graphql-clj'."
-  :url "http://example.com/FIXME"
+  :url "https://github.com/xsc/graphql-clj-bench"
   :license {:name "MIT License"
             :url "https://opensource.org/licenses/MIT"
             :year 2016

--- a/project.clj
+++ b/project.clj
@@ -6,11 +6,14 @@
             :year 2016
             :key "mit"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [graphql-clj "0.1.16"]
+                 [graphql-clj "0.1.20-SNAPSHOT"]
+                 [clojure-future-spec "1.9.0-alpha13"]
+                 [org.clojure/core.match "0.3.0-alpha4"]
                  [perforate "0.3.4"]]
   :plugins [[perforate "0.3.4"]]
   :perforate
   {:benchmark-paths ["src"]
    :environments
    [{:name :query-parser
-     :namespaces [graphql-clj-bench.query-parser]}]})
+     :namespaces [graphql-clj-bench.query-parser
+                  graphql-clj-bench.query-execution]}]})

--- a/project.clj
+++ b/project.clj
@@ -15,5 +15,6 @@
   {:benchmark-paths ["src"]
    :environments
    [{:name :query-parser
-     :namespaces [graphql-clj-bench.query-parser
-                  graphql-clj-bench.query-execution]}]})
+     :namespaces [graphql-clj-bench.query-parser]}
+    {:name :query-executor
+     :namespaces [graphql-clj-bench.query-executor]}]})

--- a/src/graphql_clj_bench/query_execution.clj
+++ b/src/graphql_clj_bench/query_execution.clj
@@ -1,0 +1,48 @@
+(ns graphql-clj-bench.query-execution
+  (:require [perforate.core :refer [defgoal defcase]]
+            [graphql-clj.executor :as executor]
+            [graphql-clj.parser :as parser]
+            [graphql-clj.validator :as validator]
+            [graphql-clj.resolver :as resolver]
+            [graphql-clj-bench.scenarios.starwars :as s-sw]))
+
+(defn- prep-statement*
+  "Helper function to cache statement parsing and validation output"
+  ([schema statement-str]
+   (-> statement-str parser/parse (validator/validate-statement schema)))
+  ([schema resolver-fn statement-str]
+   (let [resolver-fn (resolver/create-resolver-fn schema resolver-fn)
+         schema-w-resolver (assoc schema :resolver resolver-fn)] ;; Enable inlining resolver functions
+     (prep-statement* schema-w-resolver statement-str))))
+(def prep-statement (memoize prep-statement*))
+
+(def query-str
+  "query {\n  human (id:\"1002\") {\n    id\n    name\n    friends {\n      id\n      name\n      friends {\n        id\n      }\n    }\n  }\n}")
+
+(declare no-precompilation)
+(defgoal no-precompilation "Verifying GraphQL query string parsing, validation, and execution overhead.")
+
+(defcase no-precompilation :nested-query []
+  (executor/execute nil s-sw/starwars-schema s-sw/starwars-resolver-fn query-str))
+
+(declare precompilation)
+(defgoal precompilation "Verifying GraphQL query execution overhead for an already parsed and validated query string.")
+
+(def valid-query (prep-statement s-sw/starwars-schema query-str))
+
+(defcase precompilation :nested-query []
+  (executor/execute nil s-sw/starwars-schema s-sw/starwars-resolver-fn valid-query))
+
+(declare caching)
+(defgoal caching "Verifying GraphQL query execution overhead when caching query string parsing and validation.")
+
+(defcase caching :nested-query []
+  (->> (prep-statement s-sw/starwars-schema query-str)
+       (executor/execute nil s-sw/starwars-schema s-sw/starwars-resolver-fn)))
+
+;(declare inline-resolvers)
+;(defgoal inline-resolvers "Verifying GraphQL query execution overhead with inline resolver functions.")
+;
+;(defcase inline-resolvers :nested-query []
+;  (->> (prep-statement s-sw/starwars-schema s-sw/starwars-resolver-fn query-str)
+;       (executor/execute nil s-sw/starwars-schema s-sw/starwars-resolver-fn)))

--- a/src/graphql_clj_bench/query_executor.clj
+++ b/src/graphql_clj_bench/query_executor.clj
@@ -31,20 +31,13 @@
     }
   }")
 
-(declare no-caching)
-(defgoal no-caching "Verifying GraphQL query string parsing, validation, and execution overhead.")
+(defgoal query-execution "Verifying GraphQL query execution overhead")
 
-(defcase no-caching :nested-query []
-  (executor/execute nil s-sw/schema s-sw/resolver-fn query-str {:id "1002"}))
+(defcase query-execution :uncached []
+  (executor/execute nil s-sw/schema s-sw/resolver-fn query-str))
 
-(declare caching)
-(defgoal caching "Verifying GraphQL query execution overhead when caching query string parsing and validation.")
-
-(defcase caching :nested-query []
+(defcase query-execution :cached []
   (executor/execute nil s-sw/schema s-sw/resolver-fn (prep-statement s-sw/schema query-str)))
 
-(declare inline-resolvers)
-(defgoal inline-resolvers "Verifying GraphQL query execution overhead with inline resolver functions.")
-
-(defcase inline-resolvers :nested-query []
+(defcase query-execution :cached-inline-resolvers []
   (executor/execute nil s-sw/schema s-sw/resolver-fn (prep-statement s-sw/schema s-sw/resolver-fn query-str)))

--- a/src/graphql_clj_bench/query_executor.clj
+++ b/src/graphql_clj_bench/query_executor.clj
@@ -18,7 +18,7 @@
 
 (def query-str
   "query {
-    human (id: \"1002\") {
+    human(id:\"1002\") {
       id
       name
       friends {
@@ -41,3 +41,32 @@
 
 (defcase query-execution :cached-inline-resolvers []
   (executor/execute nil s-sw/schema s-sw/resolver-fn (prep-statement s-sw/schema s-sw/resolver-fn query-str)))
+
+(def query-str-vars-frag
+  "query($id:String!) {
+    human(id:$id) {
+      ...IdName
+      friends {
+        ...IdName
+        friends {
+          id
+        }
+      }
+    }
+  }
+
+  fragment IdName on Character {
+    id
+    name
+  }")
+
+(defgoal query-execution-vars-frag "Verifying GraphQL query execution overhead with variables and fragments")
+
+(defcase query-execution-vars-frag :uncached []
+  (executor/execute nil s-sw/schema s-sw/resolver-fn query-str-vars-frag {"id" "1002"}))
+
+(defcase query-execution-vars-frag :cached []
+  (executor/execute nil s-sw/schema s-sw/resolver-fn (prep-statement s-sw/schema query-str-vars-frag) {"id" "1002"}))
+
+(defcase query-execution-vars-frag :cached-inline-resolvers []
+  (executor/execute nil s-sw/schema s-sw/resolver-fn (prep-statement s-sw/schema s-sw/resolver-fn query-str-vars-frag) {"id" "1002"}))

--- a/src/graphql_clj_bench/query_executor.clj
+++ b/src/graphql_clj_bench/query_executor.clj
@@ -17,8 +17,8 @@
 (def prep-statement (memoize prep-statement*))
 
 (def query-str
-  "query($id:String!) {
-    human (id:$id) {
+  "query {
+    human (id: \"1002\") {
       id
       name
       friends {
@@ -41,10 +41,10 @@
 (defgoal caching "Verifying GraphQL query execution overhead when caching query string parsing and validation.")
 
 (defcase caching :nested-query []
-  (executor/execute nil s-sw/schema s-sw/resolver-fn (prep-statement s-sw/schema query-str) {:id "1002"}))
+  (executor/execute nil s-sw/schema s-sw/resolver-fn (prep-statement s-sw/schema query-str)))
 
 (declare inline-resolvers)
 (defgoal inline-resolvers "Verifying GraphQL query execution overhead with inline resolver functions.")
 
 (defcase inline-resolvers :nested-query []
-  (executor/execute nil s-sw/schema s-sw/resolver-fn (prep-statement s-sw/schema s-sw/resolver-fn query-str) {:id "1002"}))
+  (executor/execute nil s-sw/schema s-sw/resolver-fn (prep-statement s-sw/schema s-sw/resolver-fn query-str)))

--- a/src/graphql_clj_bench/query_executor.clj
+++ b/src/graphql_clj_bench/query_executor.clj
@@ -1,4 +1,4 @@
-(ns graphql-clj-bench.query-execution
+(ns graphql-clj-bench.query-executor
   (:require [perforate.core :refer [defgoal defcase]]
             [graphql-clj.executor :as executor]
             [graphql-clj.parser :as parser]

--- a/src/graphql_clj_bench/query_parser.clj
+++ b/src/graphql_clj_bench/query_parser.clj
@@ -52,7 +52,7 @@
      columnCount
    }
 
-   fragment Paiting on PaintingProject {
+   fragment Painting on PaintingProject {
      dominantColor { name, hexCode }
    }
    ")

--- a/src/graphql_clj_bench/scenarios/starwars.clj
+++ b/src/graphql_clj_bench/scenarios/starwars.clj
@@ -1,0 +1,144 @@
+(ns graphql-clj-bench.scenarios.starwars
+  (:require [graphql-clj.parser :as parser]
+            [graphql-clj.validator :as validator]
+            [graphql-clj.resolver :as resolver]
+            [clojure.core.match :as match]))
+
+(def starwars-schema-str "enum Episode { NEWHOPE, EMPIRE, JEDI }
+
+interface Character {
+  id: String!
+  name: String
+  friends: [Character]
+  appearsIn: [Episode]
+}
+
+type Human implements Character {
+  id: String!
+  name: String
+  friends: [Character]
+  appearsIn: [Episode]
+  homePlanet: String
+}
+
+type Droid implements Character {
+  id: String!
+  name: String
+  friends: [Character]
+  appearsIn: [Episode]
+  primaryFunction: String
+}
+
+type Query {
+  hero(episode: Episode): Character
+  human(id: String!): Human
+  droid(id: String!): Droid
+}
+
+type Mutation {
+  createHuman(name: String, friends: [String]): Human
+}
+
+schema {
+  query: Query
+  mutation: Mutation
+}")
+
+(def luke {:id "1000"
+           :name "Luke Skywalker"
+           :friends ["1002" "1003" "2000" "2001"]
+           :appearsIn [4 5 6]
+           :homePlanet "Tatooine"})
+
+(def vader {:id "1001"
+            :name "Darth Vader"
+            :friends ["1004"]
+            :appearsIn [4 5 6]
+            :homePlanet "Tatooine"})
+
+(def han {:id "1002"
+          :name "Han Solo"
+          :friends ["1000" "1003" "2001"]
+          :appearsIn [4 5 6]})
+
+(def leia {:id "1003"
+           :name "Leia Organa"
+           :friends ["1000" "1002" "2000" "2001"]
+           :appearsIn [4 5 6]
+           :homePlanet "Alderaan"})
+
+(def tarkin {:id "1004"
+             :name "Wilhuff Tarkin"
+             :friends ["1001"]
+             :appearsIn [4]})
+
+(def humanData  (atom {"1000" luke
+                       "1001" vader
+                       "1002" han
+                       "1003" leia
+                       "1004" tarkin}))
+
+(def threepio {:id "2000"
+               :name "C-3PO"
+               :friends ["1000" "1002" "1003" "2001"]
+               :appearsIn [4 5 6]
+               :primaryFunction "Protocol"})
+
+(def artoo {:id "2001"
+            :name "R2-D2"
+            :friends ["1000" "1002" "1003"]
+            :appearsIn [4 5 6]
+            :primaryFunction "Astromech"})
+
+(def droidData (atom {"2000" threepio
+                      "2001" artoo}))
+
+(defn get-human [id]
+  (get @humanData id))
+
+(defn get-droid [id]
+  (get @droidData id))
+
+(defn get-character [id]
+  (or (get-human id)
+      (get-droid id)))
+
+(defn get-friends [character]
+  (map get-character (:friends character)))
+
+(defn get-hero [episode]
+  (if (= episode 5)
+    luke
+    artoo))
+
+(def human-id (atom 2050))
+
+(defn create-human [args]
+  (let [new-human-id (str (swap! human-id inc))
+        new-human {:id new-human-id
+                   :name (get args "name")
+                   :friends (get args "friends")}]
+    (swap! humanData assoc new-human-id new-human)
+    new-human))
+
+(defn starwars-resolver-fn [type-name field-name]
+  (match/match
+    [type-name field-name]
+    ["Query" "hero"] (fn [context parent args]
+                       (get-hero (:episode args)))
+    ["Query" "human"] (fn [context parent args]
+                        (get-human (str (get args "id"))))
+    ["Query" "droid"] (fn [context parent args]
+                        (get-droid (str (get args "id"))))
+    ;; Hacky!!! Should use resolver for interface
+    ["Human" "friends"] (fn [context parent args]
+                          (get-friends parent))
+    ["Droid" "friends"] (fn [context parent args]
+                          (get-friends parent))
+    ["Character" "friends"] (fn [context parent args]
+                              (get-friends parent))
+    ["Mutation" "createHuman"] (fn [context parent args]
+                                 (create-human args))
+    :else nil))
+
+(def starwars-schema (validator/validate-schema (parser/parse starwars-schema-str)))

--- a/src/graphql_clj_bench/scenarios/starwars.clj
+++ b/src/graphql_clj_bench/scenarios/starwars.clj
@@ -1,10 +1,9 @@
 (ns graphql-clj-bench.scenarios.starwars
   (:require [graphql-clj.parser :as parser]
             [graphql-clj.validator :as validator]
-            [graphql-clj.resolver :as resolver]
             [clojure.core.match :as match]))
 
-(def starwars-schema-str "enum Episode { NEWHOPE, EMPIRE, JEDI }
+(def schema-str "enum Episode { NEWHOPE, EMPIRE, JEDI }
 
 interface Character {
   id: String!
@@ -35,13 +34,8 @@ type Query {
   droid(id: String!): Droid
 }
 
-type Mutation {
-  createHuman(name: String, friends: [String]): Human
-}
-
 schema {
   query: Query
-  mutation: Mutation
 }")
 
 (def luke {:id "1000"
@@ -113,15 +107,7 @@ schema {
 
 (def human-id (atom 2050))
 
-(defn create-human [args]
-  (let [new-human-id (str (swap! human-id inc))
-        new-human {:id new-human-id
-                   :name (get args "name")
-                   :friends (get args "friends")}]
-    (swap! humanData assoc new-human-id new-human)
-    new-human))
-
-(defn starwars-resolver-fn [type-name field-name]
+(defn resolver-fn [type-name field-name]
   (match/match
     [type-name field-name]
     ["Query" "hero"] (fn [context parent args]
@@ -137,8 +123,6 @@ schema {
                           (get-friends parent))
     ["Character" "friends"] (fn [context parent args]
                               (get-friends parent))
-    ["Mutation" "createHuman"] (fn [context parent args]
-                                 (create-human args))
     :else nil))
 
-(def starwars-schema (validator/validate-schema (parser/parse starwars-schema-str)))
+(def schema (validator/validate-schema (parser/parse schema-str)))


### PR DESCRIPTION
Given the following assumptions:
* Schema and query parsing and validation are trivially cacheable
* Many valid use cases (using variables) won't see a large number of distinct queries (and allowing dynamic queries may not be desirable from a security perspective)

The execution phase is the performance sensitive step for a graphql library, as this is overhead that will be paid on each request.  This PR adds benchmarks for the execution phase of a query (with a small schema and trivial resolution).

Schema, query, and resolver function copied from https://github.com/tendant/graphql-clj-starter/blob/master/src/graphql_clj_starter/graphql.clj#L9